### PR TITLE
:fire: Removed Access-Control-Allow-Origin header to stop conflicts w…

### DIFF
--- a/nginx/templates/snippets/security-locations.conf.template
+++ b/nginx/templates/snippets/security-locations.conf.template
@@ -20,10 +20,12 @@ add_header X-XSS-Protection "1; mode=block";
 autoindex off;
 
 # Set cookies secure
-#set_cookie_flag HttpOnly secure;
+# set_cookie_flag HttpOnly secure;
 
 # Enable CORS
-add_header Access-Control-Allow-Origin '*';
+# @see https://developer.mozilla.org/pt-BR/docs/Web/HTTP/Headers/Access-Control-Allow-Origin
+# If your app doesn't set this header you can enable it here.
+# add_header Access-Control-Allow-Origin '*';
 
 # By removing the ETag header, you disable caches and browsers from being able to validate files,
 # so they are forced to rely on your Cache-Control and Expires header.


### PR DESCRIPTION
Removed Access-Control-Allow-Origin header to stop conflicts with frameworks like Laravel that already define this header. Can be re-enabled if you want.